### PR TITLE
Add sct.conserve.memory parameter for param sweep and doublet finder

### DIFF
--- a/R/doubletFinder_v3.R
+++ b/R/doubletFinder_v3.R
@@ -1,5 +1,5 @@
 doubletFinder_v3 <- function(object, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, sct = FALSE, idents=NULL,
-                             batch.size=Inf, get.neighbor.doublets=T) {
+                             batch.size=Inf, get.neighbor.doublets=T, sct.conserve.memory=F) {
   require(Seurat); require(fields); require(KernSmooth)
 
   ## Generate new list of doublet classificatons from existing pANN vector to save time
@@ -105,7 +105,7 @@ doubletFinder_v3 <- function(object, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALS
     require(sctransform)
 
     print("Running SCTransform...")
-    seu_wdoublets <- SCTransform(seu_wdoublets)
+    seu_wdoublets <- SCTransform(seu_wdoublets, conserve.memory=sct.conserve.memory)
 
     print("Running PCA...")
     seu_wdoublets <- RunPCA(seu_wdoublets, npcs = length(PCs))

--- a/R/parallel_paramSweep_v3.R
+++ b/R/parallel_paramSweep_v3.R
@@ -1,4 +1,4 @@
-parallel_paramSweep_v3 <- function(n, n.real.cells, real.cells, pK, pN, data, orig.commands, PCs, sct)  {
+parallel_paramSweep_v3 <- function(n, n.real.cells, real.cells, pK, pN, data, orig.commands, PCs, sct, sct.conserve.memory=FALSE)  {
 
   sweep.res.list = list()
   list.ind = 0
@@ -61,7 +61,7 @@ parallel_paramSweep_v3 <- function(n, n.real.cells, real.cells, pK, pN, data, or
     seu_wdoublets <- CreateSeuratObject(counts = data_wdoublets)
 
     print("Running SCTransform...")
-    seu_wdoublets <- SCTransform(seu_wdoublets)
+    seu_wdoublets <- SCTransform(seu_wdoublets, conserve.memory=sct.conserve.memory)
 
     print("Running PCA...")
     seu_wdoublets <- RunPCA(seu_wdoublets, npcs = length(PCs))

--- a/R/paramSweep_v3.R
+++ b/R/paramSweep_v3.R
@@ -1,4 +1,4 @@
-paramSweep_v3 <- function(seu, PCs=1:10, sct = FALSE, num.cores=1) {
+paramSweep_v3 <- function(seu, PCs=1:10, sct = FALSE, num.cores=1, sct.conserve.memory=F) {
   require(Seurat); require(fields);
   ## Set pN-pK param sweep ranges
   pK <- c(0.0005, 0.001, 0.005, seq(0.01,0.3,by=0.01))
@@ -39,7 +39,9 @@ paramSweep_v3 <- function(seu, PCs=1:10, sct = FALSE, num.cores=1) {
                         data,
                         orig.commands,
                         PCs,
-                        sct,mc.cores=num.cores)
+                        sct,
+                        sct.conserve.memory,
+                        mc.cores=num.cores)
     stopCluster(cl)
   }else{
     output2 <- lapply(as.list(1:length(pN)),
@@ -51,7 +53,8 @@ paramSweep_v3 <- function(seu, PCs=1:10, sct = FALSE, num.cores=1) {
                       data,
                       orig.commands,
                       PCs,
-                      sct)
+                      sct,
+                      sct.conserve.memory)
   }
 
   ## Write parallelized output into list


### PR DESCRIPTION
I added an option for doublet finder to pass the conserve.memory parameter to the SCTransform to handle large datasets that require this memory optimization. 
This flag is still FALSE by default so it won't change the current behavior. 